### PR TITLE
chore: Remove unnecessary code in PetProxy.cs

### DIFF
--- a/FollowStandards/PetProxy.cs
+++ b/FollowStandards/PetProxy.cs
@@ -10,11 +10,6 @@ public class PetProxy
         string pet = string.Empty;
         // Call rest api to get the pet
         HttpResponseMessage response = await client.GetAsync( $"{baseUrl}/pet/{id}");
-        //handle the response
-        if (response.IsSuccessStatusCode)
-        {
-            pet = await response.Content.ReadAsStringAsync();
-        }
-        return pet;
+        
     }
 }

--- a/FollowStandards/test.cs
+++ b/FollowStandards/test.cs
@@ -1,0 +1,25 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace YourNamespace.Tests
+{
+    public class PetProxyTests
+    {
+        [Fact]
+        public async Task GetPet_ShouldReturnPet_WhenIdIsValid()
+        {
+            // Arrange
+            var expectedPet = "Expected pet data";
+            var id = 123;
+            var httpClient = new HttpClient();
+            var petProxy = new PetProxy(httpClient);
+
+            // Act
+            var actualPet = await petProxy.GetPet(id);
+
+            // Assert
+            Assert.Equal(expectedPet, actualPet);
+        }
+    }
+}


### PR DESCRIPTION
This pull request primarily involves the removal of response handling code from the `GetPet` method in `PetProxy.cs` and the addition of a new test file `test.cs`. The most significant changes are the removal of the HTTP response handling in the `GetPet` method and the creation of a new unit test for the `GetPet` method in the `PetProxyTests` class.

Changes to `FollowStandards/PetProxy.cs`:

* [`static public async Task<string> GetPet(int id)`](diffhunk://#diff-644acd4a2440ed7c1fbb6ff4a76fb2585d2edee0fdb88d6278493c81031d0715L13-R13): Removed the HTTP response handling code. This change implies that the method no longer checks if the HTTP request was successful or reads the response content.

Additions to `FollowStandards/test.cs`:

* New file `test.cs` was added, which includes a new unit test for the `GetPet` method in the `PetProxyTests` class. This test checks if the `GetPet` method returns the expected pet data when a valid ID is provided.